### PR TITLE
WIP /ping endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 project.clj
 target
+.nrepl-history

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mock-oauth2
 [![CircleCI](https://circleci.com/gh/ags799/mock-oauth2.svg?style=shield&circle-token=b96d1ef688887ea81983b7013b910ac9331ce9d0)](https://circleci.com/gh/ags799/mock-oauth2)
 
-A mock OAuth2 server
+A mock OAuth 2 server.
 
 ## Usage
 View usage instructions on our [Docker Hub page](https://hub.docker.com/r/ags799/mock-oauth2).

--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,8 @@
 (set-env! :resource-paths #{"src"}
           :dependencies `[[org.clojure/clojure ~(clojure-version)]
-                          [ags799/bootlaces "a28f269"]])
+                          [ags799/bootlaces "a28f269"]
+                          [metosin/compojure-api "2.0.0-alpha7"]
+                          [ring/ring-jetty-adapter "1.6.2"]])
 
 (task-options! jar {:main 'ags799.mock-oauth2.main})
 

--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 (set-env! :resource-paths #{"src"}
           :dependencies `[[org.clojure/clojure ~(clojure-version)]
-                          [ags799/bootlaces "a28f269"]
+                          [ags799/bootlaces "aaa5ff9"]
                           [metosin/compojure-api "2.0.0-alpha7"]
                           [ring/ring-jetty-adapter "1.6.2"]])
 

--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 (set-env! :resource-paths #{"src"}
           :dependencies `[[org.clojure/clojure ~(clojure-version)]
-                          [ags799/bootlaces "aaa5ff9"]
+                          [ags799/bootlaces "5f3c3dd"]
                           [metosin/compojure-api "2.0.0-alpha7"]
                           [ring/ring-jetty-adapter "1.6.2"]])
 

--- a/src/ags799/mock_oauth2/main.clj
+++ b/src/ags799/mock_oauth2/main.clj
@@ -1,3 +1,14 @@
-(ns ags799.mock-oauth2.main (:gen-class))
+(ns ags799.mock-oauth2.main
+  (:gen-class)
+  (:require [compojure.api.sweet]
+            [ring.adapter.jetty]
+            [ring.util.http-response]))
 
-(defn -main [] (println "Hello, world!"))
+(def app (compojure.api.sweet/api
+           {:swagger {:ui "/" :spec "/swagger.json" :data {:info {:title "Mock OAuth2" :description "A mock OAuth 2 service."}}}}
+           (compojure.api.sweet/GET "/ping" []
+             :return String
+             :summary "returns \"pong\""
+             (ring.util.http-response/ok "pong"))))
+
+(defn -main [] (ring.adapter.jetty/run-jetty app {:port 8080}))


### PR DESCRIPTION
Getting this from server when hitting `/ping` (although the response is as expected)
```
2017-10-09 02:54:17.235:WARN:oejs.HttpChannel:qtp1618269752-20: /favicon.ico
java.lang.NullPointerException: Response map is nil
        at ring.util.servlet$update_servlet_response.invokeStatic(servlet.clj:100)
        at ring.util.servlet$update_servlet_response.invoke(servlet.clj:91)
        at ring.util.servlet$update_servlet_response.invokeStatic(servlet.clj:95)
        at ring.util.servlet$update_servlet_response.invoke(servlet.clj:91)
        at ring.adapter.jetty$proxy_handler$fn__9249.invoke(jetty.clj:26)
        at ring.adapter.jetty.proxy$org.eclipse.jetty.server.handler.AbstractHandler$ff19274a.handle(Unknown Source)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
        at org.eclipse.jetty.server.Server.handle(Server.java:499)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:258)
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
        at java.lang.Thread.run(Thread.java:748)
```